### PR TITLE
Fix Python 3 complains about JSON decoding

### DIFF
--- a/removeVault.py
+++ b/removeVault.py
@@ -89,7 +89,7 @@ while job.status_code == 'InProgress':
 
 if job.status_code == 'Succeeded':
 	logging.info('Inventory retrieved, parsing data...')
-	inventory = json.loads(job.get_output().read())
+	inventory = json.loads(job.get_output().read().decode('utf-8'))
 
 	logging.info('Removing archives... please be patient, this may take some time...');
 	for archive in inventory['ArchiveList']:


### PR DESCRIPTION
Hi, thanks for merging my previous Pull-Request ( #12 ) quickly. Here's another fix for supporting Python 3.x.

Parsing JSON data raises an exception on Python 3.4:

```
Traceback (most recent call last):
  File "removeVault.py", line 92, in <module>
    inventory = json.loads(job.get_output().read())
  File "/usr/local/Cellar/python3/3.4.3/Frameworks/Python.framework/Versions/3.4/lib/python3.4/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```

This is a common migration issue happen between 2 and 3.

Ref: http://stackoverflow.com/questions/6862770/python-3-let-json-object-accept-bytes-or-let-urlopen-output-strings

I put a fix on this and confirmed deleting archives work well both on 2.7 & 3.4.
