### PR TITLE
Fix a problem where DEBUG did not enable debug log

### DIFF
--- a/removeVault.py
+++ b/removeVault.py
@@ -29,7 +29,7 @@ else:
 # Get custom logging level
 if len(sys.argv) == 4 and sys.argv[3] == 'DEBUG':
 	logging.info('Logging level set to DEBUG.')
-	logging.basicConfig(level=logging.DEBUG)
+	logging.getLogger().setLevel(logging.DEBUG)
 
 # Load credentials
 try:


### PR DESCRIPTION
Calling `basicConfig` has no effect the second time ([see docs](https://docs.python.org/2/library/logging.html#logging.basicConfig)), so this meant that `basicConfig(level=logging.DEBUG)` was not actually enabling the DEBUG level.

Solve this by using `getLogger()` to explicitly get the root logger and set its level instead.