### PR TITLE
Fix name of docker image to build in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If you don't want to install all dependencies locally you can also build and use
 Step 1) make sure you have docker installed and run
 
 ```
-docker build -t glacier-remove-vault .
+docker build -t glacier-vault-remove .
 ```
 
 Step 2) Create a credentials.json as described above


### PR DESCRIPTION
The Docker image name to be built was incorrect, so if you were to follow the instructions it wouldn't work. This PR fixes that.