### PR TITLE
A) Move to Boto3(decrease memory usage), B) Allow Role Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ Then create a `credentials.json` file in the same directory as `removeVault.py` 
 You can then use the script like this :
 
 ```shell
-python .\removeVault.py <region-name> [<vault-name>|LIST] [DEBUG] [NUM_PROCESSES]
+python .\removeVault.py <account-id> <region-name> [<vault-name>|LIST] [DEBUG] [NUM_PROCESSES]
 ```
 
 Example :
 
 ```shell
-python .\removeVault.py eu-west-1 my_vault
+python .\removeVault.py 123456789012 eu-west-1 my_vault
 ```
 
 Or if you want to perform the removal using multiple processes (4 processes here) :
 
 ```shell
-python .\removeVault.py eu-west-1 my_vault 4
+python .\removeVault.py 123456789012 eu-west-1 my_vault 4
 ```
 
 ## List
@@ -51,7 +51,7 @@ python .\removeVault.py eu-west-1 my_vault 4
 If you don't know the vault name, you can generate a list like this:
 
 ```shell
-python .\removeVault.py eu-west-1 LIST
+python .\removeVault.py 123456789012 eu-west-1 LIST
 ```
 
 ## Debug
@@ -61,7 +61,7 @@ By default, only the INFO messages will be printed to console. You can add a thi
 Example :
 
 ```shell
-python .\removeVault.py eu-west-1 my_vault DEBUG
+python .\removeVault.py 123456789012 eu-west-1 my_vault DEBUG
 ```
 
 ## Running the Docker container
@@ -79,7 +79,7 @@ Step 2) Create a credentials.json as described above
 Step 3) Run the tool in the docker container:
 
 ```
-docker run -v /path/to/credentials.json:/app/credentials.json glacier-vault-remove <region> <vault|LIST> [DEBUG] [NUM_PROCESSES]
+docker run -v /path/to/credentials.json:/app/credentials.json glacier-vault-remove <account-id> <region> <vault|LIST> [DEBUG] [NUM_PROCESSES]
 ```
 
 Make sure you use the _full_ absolute path to `credentials.json`, relative paths do not work here.

--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ Then create a `credentials.json` file in the same directory as `removeVault.py` 
 You can then use the script like this :
 
 ```shell
-python .\removeVault.py <account-id> <region-name> [<vault-name>|LIST] [DEBUG] [NUM_PROCESSES]
+python .\removeVault.py <region-name> [<vault-name>|LIST] [DEBUG] [NUM_PROCESSES]
 ```
 
 Example :
 
 ```shell
-python .\removeVault.py 123456789012 eu-west-1 my_vault
+python .\removeVault.py eu-west-1 my_vault
 ```
 
 Or if you want to perform the removal using multiple processes (4 processes here) :
 
 ```shell
-python .\removeVault.py 123456789012 eu-west-1 my_vault 4
+python .\removeVault.py eu-west-1 my_vault 4
 ```
 
 ## List
@@ -51,7 +51,7 @@ python .\removeVault.py 123456789012 eu-west-1 my_vault 4
 If you don't know the vault name, you can generate a list like this:
 
 ```shell
-python .\removeVault.py 123456789012 eu-west-1 LIST
+python .\removeVault.py eu-west-1 LIST
 ```
 
 ## Debug
@@ -61,7 +61,7 @@ By default, only the INFO messages will be printed to console. You can add a thi
 Example :
 
 ```shell
-python .\removeVault.py 123456789012 eu-west-1 my_vault DEBUG
+python .\removeVault.py eu-west-1 my_vault DEBUG
 ```
 
 ## Running the Docker container
@@ -79,7 +79,7 @@ Step 2) Create a credentials.json as described above
 Step 3) Run the tool in the docker container:
 
 ```
-docker run -v /path/to/credentials.json:/app/credentials.json glacier-vault-remove <account-id> <region> <vault|LIST> [DEBUG] [NUM_PROCESSES]
+docker run -v /path/to/credentials.json:/app/credentials.json glacier-vault-remove <region> <vault|LIST> [DEBUG] [NUM_PROCESSES]
 ```
 
 Make sure you use the _full_ absolute path to `credentials.json`, relative paths do not work here.

--- a/removeVault.py
+++ b/removeVault.py
@@ -155,7 +155,7 @@ while job['StatusCode'] == 'InProgress':
 
 	time.sleep(60*10)
 
-	job = vault.describe_job(vaultName=vaultName, jobId=jobID)
+	job = glacier.describe_job(vaultName=vaultName, jobId=jobID)
 
 if job['StatusCode'] == 'Succeeded':
 	logging.info('Inventory retrieved, parsing data...')

--- a/removeVault.py
+++ b/removeVault.py
@@ -153,12 +153,8 @@ while job['StatusCode'] == 'InProgress':
 	job = vault.describe_job(vaultName=vaultName, jobId=jobID)
 
 if job['StatusCode'] == 'Succeeded':
-	logging.info('Retrieving inventory')
-	job_output = glacier.get_job_output(
-	    vaultName=vaultName,
-	    jobId=job['JobId']
-	)
 	logging.info('Inventory retrieved, parsing data...')
+	job_output = glacier.get_job_output(vaultName=vaultName, jobId=job['JobId'])
 	inventory = json.loads(job_output['body'].read().decode('utf-8'))
 
 	archiveList = inventory['ArchiveList']

--- a/removeVault.py
+++ b/removeVault.py
@@ -55,7 +55,7 @@ if len(sys.argv) >= 3:
 	vaultName = sys.argv[2]
 else:
 	# If there are missing arguments, display usage example and exit
-	logging.error('Usage: %s <account_id> <region_name> [<vault_name>|LIST] [DEBUG] [NUMPROCESS]', sys.argv[0])
+	logging.error('Usage: %s <region_name> [<vault_name>|LIST] [DEBUG] [NUMPROCESS]', sys.argv[0])
 	sys.exit(1)
 
 # Get custom logging level

--- a/removeVault.py
+++ b/removeVault.py
@@ -74,6 +74,8 @@ elif len(sys.argv) == 6:
 		numProcess = int(sys.argv[5])
 logging.info('Running with %s processes', numProcess)
 
+os.environ['AWS_DEFAULT_REGION'] = regionName
+
 # Load credentials
 try:
 	f = open('credentials.json', 'r')

--- a/removeVault.py
+++ b/removeVault.py
@@ -133,7 +133,8 @@ for job in response['JobList']:
 if jobID == '':
 	logging.info('No existing job found, initiate inventory retrieval...')
 	try:
-		vault = glacier.Vault(accountId, vaultName)
+		glacier_resource = boto3.resource('glacier')
+		vault = glacier_resource.Vault(accountId, vaultName)
 		job = vault.initiate_inventory_retrieval()
 
 		jobID = job.id

--- a/removeVault.py
+++ b/removeVault.py
@@ -35,7 +35,7 @@ def process_archive(archive_list):
 				logging.info('Retry to remove archive ID : %s', archive['ArchiveId'])
 				try:
 					glacier.delete_archive(
-					    vaultName='vaultName',
+					    vaultName=vaultName,
 					    archiveId=archive['ArchiveId']
 					)
 					logging.info('Successfully removed archive ID : %s', archive['ArchiveId'])

--- a/removeVault.py
+++ b/removeVault.py
@@ -50,28 +50,27 @@ def printException():
 logging.basicConfig(format='%(asctime)s - %(levelname)s : %(message)s', level=logging.INFO, datefmt='%H:%M:%S')
 
 # Get arguments
-if len(sys.argv) >= 4:
-	accountId = sys.argv[1]
-	regionName = sys.argv[2]
-	vaultName = sys.argv[3]
+if len(sys.argv) >= 3:
+	regionName = sys.argv[1]
+	vaultName = sys.argv[2]
 else:
 	# If there are missing arguments, display usage example and exit
 	logging.error('Usage: %s <account_id> <region_name> [<vault_name>|LIST] [DEBUG] [NUMPROCESS]', sys.argv[0])
 	sys.exit(1)
 
 # Get custom logging level
-if len(sys.argv) == 5 and sys.argv[4] == 'DEBUG':
+if len(sys.argv) == 4 and sys.argv[3] == 'DEBUG':
 	logging.info('Logging level set to DEBUG.')
 	logging.getLogger().setLevel(logging.DEBUG)
 
 # Get number of processes
 numProcess = 1
-if len(sys.argv) == 5:
+if len(sys.argv) == 4:
+	if sys.argv[3].isdigit():
+		numProcess = int(sys.argv[3])
+elif len(sys.argv) == 5:
 	if sys.argv[4].isdigit():
 		numProcess = int(sys.argv[4])
-elif len(sys.argv) == 6:
-	if sys.argv[5].isdigit():
-		numProcess = int(sys.argv[5])
 logging.info('Running with %s processes', numProcess)
 
 os.environ['AWS_DEFAULT_REGION'] = regionName
@@ -87,6 +86,11 @@ try:
 
 except:
 	logging.error('Cannot load "credentials.json" file... Assuming Role Authentication.')
+
+sts_client = boto3.client("sts")
+accountId = sts_client.get_caller_identity()["Account"]
+
+logging.info("Working on AccountID: {id}".format(id=accountId))
 
 try:
 	logging.info('Connecting to Amazon Glacier...')

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
 
     # Project uses reStructuredText, so ensure that the docutils get
     # installed or upgraded on the target machine
-    install_requires = ['boto>=2.9.9'],
+    install_requires = ['3>=1.4.4'],
 
     # metadata for upload to PyPI
     author = "Leeroy Brun",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
 
     # Project uses reStructuredText, so ensure that the docutils get
     # installed or upgraded on the target machine
-    install_requires = ['3>=1.4.4'],
+    install_requires = ['boto3>=1.4.4'],
 
     # metadata for upload to PyPI
     author = "Leeroy Brun",


### PR DESCRIPTION
## Move to Boto3(decrease memory usage)

With my large vaults (500k+ Archives), I was unable to delete the whole vault without running in a memory depletion. Even on a `r4.2xlarge` EC2 machine from AWS (61GB RAM).

With some research, it was looking like boto was leaking on each request.
With the move toward boto3, the same run takes no more than ~400Mb.

~Caveat: Boto3 needed AWS's account id. It's now required in the run args.~

## Allow role Authentication

I needed the script to run on an EC2 with access to Glacier via a IAM Role.