### PR TITLE
Fix tabs and spaces

### DIFF
--- a/removeVault.py
+++ b/removeVault.py
@@ -81,7 +81,7 @@ try:
 	config = json.loads(f.read())
 	f.close()
 
- 	os.environ['AWS_ACCESS_KEY_ID'] = config['AWSAccessKeyId']
+	os.environ['AWS_ACCESS_KEY_ID'] = config['AWSAccessKeyId']
 	os.environ['AWS_SECRET_ACCESS_KEY'] = config['AWSSecretKey']
 
 except:


### PR DESCRIPTION
Fixes error

```
  File "C:/Projects/glacier-vault-remove/removeVault.py", line 84
    os.environ['AWS_ACCESS_KEY_ID'] = config['AWSAccessKeyId']
                                                             ^
TabError: inconsistent use of tabs and spaces in indentation
```