### PR TITLE
Fix starting new process

### DIFF
--- a/removeVault.py
+++ b/removeVault.py
@@ -157,7 +157,7 @@ while job['StatusCode'] == 'InProgress':
 
 	job = glacier.describe_job(vaultName=vaultName, jobId=jobID)
 
-if job['StatusCode'] == 'Succeeded':
+if job['StatusCode'] == 'Succeeded' and __name__ == '__main__':
 	logging.info('Inventory retrieved, parsing data...')
 	job_output = glacier.get_job_output(vaultName=vaultName, jobId=job['JobId'])
 	inventory = json.loads(job_output['body'].read().decode('utf-8'))


### PR DESCRIPTION
Fixes error

```
RuntimeError:
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
    ForkingPickler(file, protocol).dump(obj)
BrokenPipeError: [Errno 32] Broken pipe
```