### PR TITLE
List all vaults if there are more than 10

### DIFF
--- a/removeVault.py
+++ b/removeVault.py
@@ -103,11 +103,15 @@ if vaultName == 'LIST':
 	try:
 		logging.info('Getting list of vaults...')
 		response = glacier.list_vaults()
+		vault_list = response.get('VaultList')
+		while response.get('Marker') is not None:
+			response = glacier.list_vaults(marker=response['Marker'])
+			vault_list += response.get('VaultList')
 	except:
 		printException()
 		sys.exit(1)
 
-	for vault in response['VaultList']:
+	for vault in vault_list:
 		logging.info(vault['VaultName'])
 
 	exit(0)


### PR DESCRIPTION
By default `list_vaults` method returns only 10 vaults. If there are more vaults - those were not listed.

Response object contains `Marker` value if there are more than 10 vaults in the account. The `Marker` value should be provided as parameter to `list_vaults` method to retrieve list of further vaults. Such requests needs to be repeated until `Marker` is not present in the response.